### PR TITLE
Add jquery as npm dependency

### DIFF
--- a/{{cookiecutter.project_name}}/package.json
+++ b/{{cookiecutter.project_name}}/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "bootstrap": "^3.3.5"
+    "bootstrap": "^3.3.5",
+    "jquery": "^2.1.4"
   }
 }


### PR DESCRIPTION
Bootstrap needs it, and it's even requested in the base template: https://github.com/wildfish/wildfish-django-starter/blob/34cfea738c2a07f4526186bc0c6ef208e36517d5/%7B%7Bcookiecutter.project_name%7D%7D/templates/base.html#L52