### PR TITLE
Feature/whitenoise

### DIFF
--- a/{{cookiecutter.project_name}}/requirements.in
+++ b/{{cookiecutter.project_name}}/requirements.in
@@ -20,4 +20,4 @@ uwsgi
 django-configurations
 -e git+git://github.com/pashinin/fabric@p33#egg=fabric
 whitenoise
-brotlipy
+# brotlipy

--- a/{{cookiecutter.project_name}}/requirements.in
+++ b/{{cookiecutter.project_name}}/requirements.in
@@ -19,3 +19,5 @@ django-clear-cache
 uwsgi
 django-configurations
 -e git+git://github.com/pashinin/fabric@p33#egg=fabric
+whitenoise
+brotlipy

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -139,7 +139,7 @@ class Common(Configuration):
         join(BASE_DIR, 'node_modules'),
     ]
 
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    # STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
     FIXTURE_DIRS = [
         join(BASE_DIR, 'fixtures')

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -50,6 +50,7 @@ class Common(Configuration):
         'django.contrib.contenttypes',
         'django.contrib.sessions',
         'django.contrib.messages',
+        'whitenoise.runserver_nostatic',
         'django.contrib.staticfiles',
         'raven.contrib.django.raven_compat',
         'debug_toolbar',
@@ -61,6 +62,7 @@ class Common(Configuration):
 
     MIDDLEWARE = [
         'django.middleware.security.SecurityMiddleware',
+        'whitenoise.middleware.WhiteNoiseMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
@@ -135,6 +137,8 @@ class Common(Configuration):
         join(BASE_DIR, 'static'),
         join(BASE_DIR, 'node_modules'),
     ]
+
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
     FIXTURE_DIRS = [
         join(BASE_DIR, 'fixtures')


### PR DESCRIPTION
I left compressed storage and brotlipy commented out as it will inevitably result in lots of issues from people with trouble installing the dependencies. This way it's opt in.