### PR TITLE
Actually enable django_debug_toolbar

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/settings.py
@@ -206,6 +206,7 @@ class Dev(Common):
     DEBUG = True
     EMAIL_BACKEND = 'django.core.mail.backends.filebased.EmailBackend'
     EMAIL_FILE_PATH = '/tmp/app-emails'
+    INTERNAL_IPS = ['127.0.0.1', ]
 
 
 class Deployed(RedisCache, Common):

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/urls.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/urls.py
@@ -14,3 +14,10 @@ urlpatterns = [
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if 'debug_toolbar' in settings.INSTALLED_APPS:
+    import debug_toolbar
+
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]


### PR DESCRIPTION
Some settings were missing, so django_debug_toolbar was never loaded during development.

This PR adds the missing settings with sane defaults.

Great project btw! I am using it for one of my projects right now. Sane defaults and a simple base setup, just as I like it. Keep it up!